### PR TITLE
Added infinite scrolling

### DIFF
--- a/components/atoms/InfiniteScroll.vue
+++ b/components/atoms/InfiniteScroll.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<script>
+import { defineComponent, toRefs, watch } from '@vue/composition-api'
+import { onBeforeUnmount, onMounted } from '@nuxtjs/composition-api'
+
+const DEFAULT_LOAD_GAP = 400
+export default defineComponent({
+  props: {
+    contentChangeKey: {
+      type: Number,
+      default: 0,
+      required: true,
+    },
+  },
+  setup(props, { emit }) {
+    const { contentChangeKey } = toRefs(props)
+    let locked = false
+    const loadGap = DEFAULT_LOAD_GAP
+
+    watch(contentChangeKey, () => {
+      locked = false
+    })
+
+    onMounted(() => {
+      window.addEventListener('scroll', fetchNextBlockIfNeeded)
+    })
+
+    onBeforeUnmount(() => {
+      window.removeEventListener('scroll', fetchNextBlockIfNeeded)
+    })
+
+    function fetchNextBlockIfNeeded(e) {
+      const div = e.target.documentElement
+      const divGap = div.scrollHeight - div.clientHeight - div.scrollTop
+      if (divGap < loadGap) {
+        if (!locked) {
+          locked = true
+          emit('fetchNextBlock')
+        }
+      }
+    }
+    return {
+      fetchNextBlockIfNeeded,
+    }
+  },
+})
+</script>
+
+<style scoped></style>

--- a/pages/adventurer/index.vue
+++ b/pages/adventurer/index.vue
@@ -35,7 +35,12 @@
           {{ button.label }}
         </BButton>
       </div>
-      <div v-if="!$fetchState.pending" class="flex flex-wrap">
+      <InfiniteScroll
+        v-if="!$fetchState.pending"
+        class="flex flex-wrap"
+        :content-change-key="adventurers.length"
+        @fetchNextBlock="fetchMore"
+      >
         <div
           v-for="(adventurer, index) in adventurers"
           :key="index"
@@ -43,10 +48,14 @@
         >
           <AdventurerCard :adventurer="adventurer" />
         </div>
-        <BButton :loading="loading" type="primary" @click.native="fetchMore"
-          >Load more</BButton
-        >
-      </div>
+        <template v-if="loading">
+          <Loader
+            v-for="(loader, index) in 4"
+            :key="'dummy' + index"
+            class="mr-3 mb-3"
+          />
+        </template>
+      </InfiniteScroll>
       <div v-else class="flex flex-wrap mt-4">
         <Loader v-for="(loader, index) in 6" :key="index" class="mr-3 mb-3" />
       </div>
@@ -62,10 +71,11 @@ import {
   useContext,
   useFetch,
 } from '@nuxtjs/composition-api'
+import InfiniteScroll from '../../components/atoms/InfiniteScroll'
 import AdventurerCard from '~/components/cards/AdventurerCard.vue'
 
 export default defineComponent({
-  components: { AdventurerCard },
+  components: { InfiniteScroll, AdventurerCard },
   setup(props, context) {
     const getQuery = (param) => {
       return ref(gql`

--- a/pages/loot/index.vue
+++ b/pages/loot/index.vue
@@ -21,11 +21,23 @@
       </BButton>
     </form>
     <div v-if="!$fetchState.pending">
-      <div v-if="!queryLoading" class="flex flex-wrap">
+      <InfiniteScroll
+        v-if="!queryLoading"
+        class="flex flex-wrap"
+        :content-change-key="loot.length"
+        @fetchNextBlock="fetchMore"
+      >
         <div v-for="(l, index) in loot" :key="index" class="w-80">
           <LootCard is-o-g :loot="l" />
         </div>
-      </div>
+        <template v-if="loading">
+          <Loader
+            v-for="(loader, index) in 4"
+            :key="'dummy' + index"
+            class="mr-3 mb-3"
+          />
+        </template>
+      </InfiniteScroll>
 
       <div v-if="queryLoading" class="flex flex-wrap mt-8">
         <Loader v-for="(loader, index) in 4" :key="index" class="mr-3 mb-3" />
@@ -33,15 +45,6 @@
       <div v-if="!queryLoading && !loot.length" class="my-3">
         <div class="text-2xl">No Loot found - Try adjusting your query.</div>
       </div>
-      <BButton
-        v-if="loot.length > 1"
-        :disabled="queryLoading"
-        :loading="loading"
-        type="primary"
-        class="mt-8"
-        @click.native="fetchMore"
-        >{{ loading ? 'loading' : 'Load more loot' }}</BButton
-      >
     </div>
     <div v-else class="mt-4">
       <Loader />
@@ -57,8 +60,11 @@ import {
   useContext,
   useFetch,
 } from '@nuxtjs/composition-api'
+import InfiniteScroll from '../../components/atoms/InfiniteScroll'
+import Loader from '../../components/Loader'
 
 export default defineComponent({
+  components: { Loader, InfiniteScroll },
   setup(props, context) {
     const { $graphql } = useContext()
     const search = ref()

--- a/pages/manas/index.vue
+++ b/pages/manas/index.vue
@@ -20,14 +20,22 @@
     </div>
 
     <div v-if="!$fetchState.pending" class="mt-8">
-      <div class="flex flex-wrap">
+      <InfiniteScroll
+        class="flex flex-wrap"
+        :content-change-key="manas.length"
+        @fetchNextBlock="fetchMore"
+      >
         <div v-for="(mana, index) in manas" :key="index" class="w-80">
           <ManaCard :mana="mana" />
         </div>
-      </div>
-      <BButton :loading="loading" type="primary" @click.native="fetchMore"
-        >Load more</BButton
-      >
+        <template v-if="loading">
+          <Loader
+            v-for="(loader, index) in 4"
+            :key="'dummy' + index"
+            class="mr-3 mb-3"
+          />
+        </template>
+      </InfiniteScroll>
     </div>
     <div v-else class="mt-8">
       <Loader />
@@ -43,8 +51,10 @@ import {
   useContext,
   useFetch,
 } from '@nuxtjs/composition-api'
+import InfiniteScroll from '../../components/atoms/InfiniteScroll'
 
 export default defineComponent({
+  components: { InfiniteScroll },
   setup(props, context) {
     const { $graphql } = useContext()
     const search = ref()

--- a/pages/realms/index.vue
+++ b/pages/realms/index.vue
@@ -39,22 +39,25 @@
         <span>Rarity ranges between 5 and 8300 - higher scores are better</span>
       </div>
 
-      <div v-if="!$fetchState.pending" class="flex flex-wrap w-full">
+      <InfiniteScroll
+        v-if="!$fetchState.pending"
+        class="flex flex-wrap w-full"
+        :content-change-key="openSeaData.length"
+        @fetchNextBlock="fetchMoreRealms"
+      >
         <div v-for="realm in openSeaData" :key="realm.id" class="w-80">
           <RealmCard :id="realm.token_id" :realm="realm" />
         </div>
-      </div>
+        <template v-if="loading">
+          <Loader
+            v-for="(loader, index) in 4"
+            :key="'dummy' + index"
+            class="mr-3 mb-3"
+          />
+        </template>
+      </InfiniteScroll>
       <div v-else class="flex flex-wrap mt-6">
         <Loader v-for="(loader, index) in 6" :key="index" class="mr-3 mb-3" />
-      </div>
-
-      <div v-if="!$fetchState.pending">
-        <button
-          class="bg-black rounded px-4 py-2 hover:bg-gray-700"
-          @click="fetchMoreRealms"
-        >
-          {{ loading ? 'loading' : 'Load More Realms' }}
-        </button>
       </div>
     </div>
   </section>
@@ -63,16 +66,18 @@
 <script>
 import { defineComponent, ref, useFetch } from '@nuxtjs/composition-api'
 import axios from 'axios'
+import InfiniteScroll from '../../components/atoms/InfiniteScroll'
 import { useFormatting } from '~/composables/useFormatting'
 
 export default defineComponent({
+  components: { InfiniteScroll },
   setup(props, context) {
     const { shortenHash } = useFormatting()
 
     const adventurer = ref(null)
     const usersGold = ref(null)
     const search = ref()
-    const openSeaData = ref()
+    const openSeaData = ref([])
     const loading = ref()
     const orderBy = ref()
     const offset = ref(0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -13831,6 +13831,11 @@ vue-router@^3.5.1:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.2.tgz#5f55e3f251970e36c3e8d88a7cd2d67a350ade5c"
   integrity sha512-807gn82hTnjCYGrnF3eNmIw/dk7/GE4B5h69BlyCK9KHASwSloD1Sjcn06zg9fVG4fYH2DrsNBZkpLtb25WtaQ==
 
+vue-scroll@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/vue-scroll/-/vue-scroll-2.1.13.tgz#43e29f43fd64d52ff2856877c2d0c5b0f6433188"
+  integrity sha512-GQnDA1UcFSdmL2Gjo/3+0jlOwvRvSpdzl+q+vOtQsAjb+uQDo8UG1RKxyoQ1lkJCz5uM8OSqb/6+L3LBqInk2w==
+
 vue-server-renderer@^2.6.12:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz#c8bffff152df6b47b858818ef8d524d2fc351654"


### PR DESCRIPTION
This PR removes "Load more" button on Adventureres, Loot, Realms and Genesis Mana pages and replaces its logic with infinite scrolling.
Now instead of pressing button new content will be fetched automatically when user scrolled to the end of page.